### PR TITLE
Update and fix argocd manifests

### DIFF
--- a/argocd/app/argo-non-crds.yaml
+++ b/argocd/app/argo-non-crds.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -169,14 +168,21 @@ rules:
       - list
       - watch
   - apiGroups:
-      - apps
-      - extensions
+      - coordination.k8s.io
     resources:
-      - deployments
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resourceNames:
+      - 58ac56fa.applicationsets.argoproj.io
+    resources:
+      - leases
     verbs:
       - get
-      - list
-      - watch
+      - update
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -320,15 +326,15 @@ metadata:
   name: argocd-application-controller
 rules:
   - apiGroups:
-      - "*"
+      - '*'
     resources:
-      - "*"
+      - '*'
     verbs:
-      - "*"
+      - '*'
   - nonResourceURLs:
-      - "*"
+      - '*'
     verbs:
-      - "*"
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -356,19 +362,19 @@ rules:
   - apiGroups:
       - argoproj.io
     resources:
-      - applicationsets/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - argoproj.io
-    resources:
       - appprojects
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applicationsets/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - ""
     resources:
@@ -382,28 +388,8 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
-    verbs:
-      - create
-      - update
-      - delete
-      - get
-      - list
-      - patch
-      - watch
-  - apiGroups:
-      - ""
-    resources:
       - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apps
-      - extensions
-    resources:
-      - deployments
+      - configmaps
     verbs:
       - get
       - list
@@ -414,12 +400,16 @@ rules:
       - leases
     verbs:
       - create
-      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resourceNames:
+      - 58ac56fa.applicationsets.argoproj.io
+    resources:
+      - leases
+    verbs:
       - get
-      - list
-      - patch
       - update
-      - watch
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -431,9 +421,9 @@ metadata:
   name: argocd-server
 rules:
   - apiGroups:
-      - "*"
+      - '*'
     resources:
-      - "*"
+      - '*'
     verbs:
       - delete
       - get
@@ -621,6 +611,100 @@ subjects:
     namespace: argocd
 ---
 apiVersion: v1
+data:
+  resource.customizations.ignoreResourceUpdates.ConfigMap: |
+    jqPathExpressions:
+      # Ignore the cluster-autoscaler status
+      - '.metadata.annotations."cluster-autoscaler.kubernetes.io/last-updated"'
+      # Ignore the annotation of the legacy Leases election
+      - '.metadata.annotations."control-plane.alpha.kubernetes.io/leader"'
+  resource.customizations.ignoreResourceUpdates.Endpoints: |
+    jsonPointers:
+      - /metadata
+      - /subsets
+  resource.customizations.ignoreResourceUpdates.all: |
+    jsonPointers:
+      - /status
+  resource.customizations.ignoreResourceUpdates.apps_ReplicaSet: |
+    jqPathExpressions:
+      - '.metadata.annotations."deployment.kubernetes.io/desired-replicas"'
+      - '.metadata.annotations."deployment.kubernetes.io/max-replicas"'
+      - '.metadata.annotations."rollout.argoproj.io/desired-replicas"'
+  resource.customizations.ignoreResourceUpdates.argoproj.io_Application: |
+    jqPathExpressions:
+      - '.metadata.annotations."notified.notifications.argoproj.io"'
+      - '.metadata.annotations."argocd.argoproj.io/refresh"'
+      - '.metadata.annotations."argocd.argoproj.io/hydrate"'
+      - '.operation'
+  resource.customizations.ignoreResourceUpdates.argoproj.io_Rollout: |
+    jqPathExpressions:
+      - '.metadata.annotations."notified.notifications.argoproj.io"'
+  resource.customizations.ignoreResourceUpdates.autoscaling_HorizontalPodAutoscaler: |
+    jqPathExpressions:
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/behavior"'
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/conditions"'
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/metrics"'
+      - '.metadata.annotations."autoscaling.alpha.kubernetes.io/current-metrics"'
+  resource.customizations.ignoreResourceUpdates.discovery.k8s.io_EndpointSlice: |
+    jsonPointers:
+      - /metadata
+      - /endpoints
+      - /ports
+  resource.exclusions: |
+    ### Network resources created by the Kubernetes control plane and excluded to reduce the number of watched events and UI clutter
+    - apiGroups:
+      - ''
+      - discovery.k8s.io
+      kinds:
+      - Endpoints
+      - EndpointSlice
+    ### Internal Kubernetes resources excluded reduce the number of watched events
+    - apiGroups:
+      - coordination.k8s.io
+      kinds:
+      - Lease
+    ### Internal Kubernetes Authz/Authn resources excluded reduce the number of watched events
+    - apiGroups:
+      - authentication.k8s.io
+      - authorization.k8s.io
+      kinds:
+      - SelfSubjectReview
+      - TokenReview
+      - LocalSubjectAccessReview
+      - SelfSubjectAccessReview
+      - SelfSubjectRulesReview
+      - SubjectAccessReview
+    ### Intermediate Certificate Request excluded reduce the number of watched events
+    - apiGroups:
+      - certificates.k8s.io
+      kinds:
+      - CertificateSigningRequest
+    - apiGroups:
+      - cert-manager.io
+      kinds:
+      - CertificateRequest
+    ### Cilium internal resources excluded reduce the number of watched events and UI Clutter
+    - apiGroups:
+      - cilium.io
+      kinds:
+      - CiliumIdentity
+      - CiliumEndpoint
+      - CiliumEndpointSlice
+    ### Kyverno intermediate and reporting resources excluded reduce the number of watched events and improve performance
+    - apiGroups:
+      - kyverno.io
+      - reports.kyverno.io
+      - wgpolicyk8s.io
+      kinds:
+      - PolicyReport
+      - ClusterPolicyReport
+      - EphemeralReport
+      - ClusterEphemeralReport
+      - AdmissionReport
+      - ClusterAdmissionReport
+      - BackgroundScanReport
+      - ClusterBackgroundScanReport
+      - UpdateRequest
 kind: ConfigMap
 metadata:
   labels:
@@ -1032,6 +1116,12 @@ spec:
                   key: applicationsetcontroller.enable.scm.providers
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_GITHUB_API_METRICS
+              valueFrom:
+                configMapKeyRef:
+                  key: applicationsetcontroller.enable.github.api.metrics
+                  name: argocd-cmd-params-cm
+                  optional: true
             - name: ARGOCD_APPLICATIONSET_CONTROLLER_WEBHOOK_PARALLELISM_LIMIT
               valueFrom:
                 configMapKeyRef:
@@ -1044,7 +1134,13 @@ spec:
                   key: applicationsetcontroller.requeue.after
                   name: argocd-cmd-params-cm
                   optional: true
-          image: quay.io/argoproj/argocd:latest
+            - name: ARGOCD_APPLICATIONSET_CONTROLLER_MAX_RESOURCES_STATUS_COUNT
+              valueFrom:
+                configMapKeyRef:
+                  key: applicationsetcontroller.status.max.resources.count
+                  name: argocd-cmd-params-cm
+                  optional: true
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: Always
           name: argocd-applicationset-controller
           ports:
@@ -1074,6 +1170,8 @@ spec:
               name: tmp
             - mountPath: /app/config/reposerver/tls
               name: argocd-repo-server-tls
+            - mountPath: /home/argocd/params
+              name: argocd-cmd-params-cm
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: argocd-applicationset-controller
@@ -1102,6 +1200,13 @@ spec:
                 path: ca.crt
             optional: true
             secretName: argocd-repo-server-tls
+        - configMap:
+            items:
+              - key: applicationsetcontroller.profile.enabled
+                path: profiler.enabled
+            name: argocd-cmd-params-cm
+            optional: true
+          name: argocd-cmd-params-cm
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1158,7 +1263,7 @@ spec:
                   key: dexserver.disable.tls
                   name: argocd-cmd-params-cm
                   optional: true
-          image: ghcr.io/dexidp/dex:v2.45.1
+          image: ghcr.io/dexidp/dex:v2.43.0
           imagePullPolicy: Always
           name: dex
           ports:
@@ -1187,7 +1292,7 @@ spec:
             - -n
             - /usr/local/bin/argocd
             - /shared/argocd-dex
-          image: quay.io/argoproj/argocd:latest
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: Always
           name: copyutil
           securityContext:
@@ -1283,7 +1388,7 @@ spec:
                   key: notificationscontroller.repo.server.plaintext
                   name: argocd-cmd-params-cm
                   optional: true
-          image: quay.io/argoproj/argocd:latest
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: Always
           livenessProbe:
             tcpSocket:
@@ -1369,7 +1474,7 @@ spec:
                 secretKeyRef:
                   key: auth
                   name: argocd-redis
-          image: redis:8.6.2-alpine
+          image: public.ecr.aws/docker/library/redis:8.2.3-alpine
           imagePullPolicy: Always
           name: redis
           ports:
@@ -1385,7 +1490,7 @@ spec:
             - argocd
             - admin
             - redis-initial-password
-          image: quay.io/argoproj/argocd:latest
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: IfNotPresent
           name: secret-init
           securityContext:
@@ -1616,6 +1721,24 @@ spec:
                   key: reposerver.disable.helm.manifest.max.extracted.size
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: ARGOCD_REPO_SERVER_OCI_MANIFEST_MAX_EXTRACTED_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  key: reposerver.oci.manifest.max.extracted.size
+                  name: argocd-cmd-params-cm
+                  optional: true
+            - name: ARGOCD_REPO_SERVER_DISABLE_OCI_MANIFEST_MAX_EXTRACTED_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  key: reposerver.disable.oci.manifest.max.extracted.size
+                  name: argocd-cmd-params-cm
+                  optional: true
+            - name: ARGOCD_REPO_SERVER_OCI_LAYER_MEDIA_TYPES
+              valueFrom:
+                configMapKeyRef:
+                  key: reposerver.oci.layer.media.types
+                  name: argocd-cmd-params-cm
+                  optional: true
             - name: ARGOCD_REVISION_CACHE_LOCK_TIMEOUT
               valueFrom:
                 configMapKeyRef:
@@ -1640,6 +1763,12 @@ spec:
                   key: reposerver.git.request.timeout
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: ARGOCD_REPO_SERVER_ENABLE_BUILTIN_GIT_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  key: reposerver.enable.builtin.git.config
+                  name: argocd-cmd-params-cm
+                  optional: true
             - name: ARGOCD_GRPC_MAX_SIZE_MB
               valueFrom:
                 configMapKeyRef:
@@ -1658,7 +1787,7 @@ spec:
               value: /helm-working-dir
             - name: HELM_DATA_HOME
               value: /helm-working-dir
-          image: quay.io/argoproj/argocd:latest
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3
@@ -1705,12 +1834,12 @@ spec:
             - mountPath: /home/argocd/cmp-server/plugins
               name: plugins
       initContainers:
-        - command:
-            - /bin/cp
-            - -n
-            - /usr/local/bin/argocd
-            - /var/run/argocd/argocd-cmp-server
-          image: quay.io/argoproj/argocd:latest
+        - args:
+            - /bin/cp /usr/local/bin/argocd /var/run/argocd/argocd && /bin/ln -sf /var/run/argocd/argocd /var/run/argocd/argocd-cmp-server
+          command:
+            - sh
+            - -c
+          image: quay.io/argoproj/argocd:v3.3.8
           name: copyutil
           securityContext:
             allowPrivilegeEscalation: false
@@ -1926,12 +2055,6 @@ spec:
                   key: server.oidc.cache.expiration
                   name: argocd-cmd-params-cm
                   optional: true
-            - name: ARGOCD_SERVER_LOGIN_ATTEMPTS_EXPIRATION
-              valueFrom:
-                configMapKeyRef:
-                  key: server.login.attempts.expiration
-                  name: argocd-cmd-params-cm
-                  optional: true
             - name: ARGOCD_SERVER_STATIC_ASSETS
               valueFrom:
                 configMapKeyRef:
@@ -2070,6 +2193,12 @@ spec:
                   key: applicationsetcontroller.enable.scm.providers
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: ARGOCD_APPLICATIONSET_CONTROLLER_ENABLE_GITHUB_API_METRICS
+              valueFrom:
+                configMapKeyRef:
+                  key: applicationsetcontroller.enable.github.api.metrics
+                  name: argocd-cmd-params-cm
+                  optional: true
             - name: ARGOCD_HYDRATOR_ENABLED
               valueFrom:
                 configMapKeyRef:
@@ -2082,7 +2211,7 @@ spec:
                   key: server.sync.replace.allowed
                   name: argocd-cmd-params-cm
                   optional: true
-          image: quay.io/argoproj/argocd:latest
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: Always
           livenessProbe:
             httpGet:
@@ -2308,6 +2437,18 @@ spec:
                   key: controller.self.heal.backoff.cap.seconds
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: ARGOCD_APPLICATION_CONTROLLER_SELF_HEAL_BACKOFF_COOLDOWN_SECONDS
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.self.heal.backoff.cooldown.seconds
+                  name: argocd-cmd-params-cm
+                  optional: true
+            - name: ARGOCD_SYNC_WAVE_DELAY
+              valueFrom:
+                configMapKeyRef:
+                  key: controller.sync.wave.delay.seconds
+                  name: argocd-cmd-params-cm
+                  optional: true
             - name: ARGOCD_APPLICATION_CONTROLLER_SYNC_TIMEOUT
               valueFrom:
                 configMapKeyRef:
@@ -2446,9 +2587,15 @@ spec:
                   key: controller.cluster.cache.events.processing.interval
                   name: argocd-cmd-params-cm
                   optional: true
+            - name: ARGOCD_APPLICATION_CONTROLLER_COMMIT_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  key: commit.server
+                  name: argocd-cmd-params-cm
+                  optional: true
             - name: KUBECACHEDIR
               value: /tmp/kubecache
-          image: quay.io/argoproj/argocd:latest
+          image: quay.io/argoproj/argocd:v3.3.8
           imagePullPolicy: Always
           name: argocd-application-controller
           ports:
@@ -2508,6 +2655,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/component: application-controller
+    app.kubernetes.io/name: argocd-application-controller
+    app.kubernetes.io/part-of: argocd
   name: argocd-application-controller-network-policy
 spec:
   ingress:
@@ -2524,6 +2675,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/component: applicationset-controller
+    app.kubernetes.io/name: argocd-applicationset-controller
+    app.kubernetes.io/part-of: argocd
   name: argocd-applicationset-controller-network-policy
 spec:
   ingress:
@@ -2543,6 +2698,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/component: dex-server
+    app.kubernetes.io/name: argocd-dex-server
+    app.kubernetes.io/part-of: argocd
   name: argocd-dex-server-network-policy
 spec:
   ingress:
@@ -2590,6 +2749,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: argocd-redis
+    app.kubernetes.io/part-of: argocd
   name: argocd-redis-network-policy
 spec:
   ingress:
@@ -2615,6 +2778,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/component: repo-server
+    app.kubernetes.io/name: argocd-repo-server
+    app.kubernetes.io/part-of: argocd
   name: argocd-repo-server-network-policy
 spec:
   ingress:
@@ -2647,6 +2814,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/part-of: argocd
   name: argocd-server-network-policy
 spec:
   ingress:

--- a/argocd/app/deployment.yaml
+++ b/argocd/app/deployment.yaml
@@ -11,13 +11,11 @@ spec:
     spec:
       initContainers:
         - name: install-ksops
-          image: viaductoss/ksops:v4.5.1
+          image: viaductoss/ksops:v4.3.3
           command: ["/bin/sh", "-c"]
           args:
-            - echo "Installing KSOPS...";
-              mv ksops /custom-tools/;
-              mv kustomize /custom-tools/;
-              echo "Done.";
+            - echo "Installing KSOPS..."; mv ksops /custom-tools/; mv kustomize
+              /custom-tools/; echo "Done.";
           volumeMounts:
             - mountPath: /custom-tools
               name: custom-tools

--- a/argocd/update-argo-manifests.sh
+++ b/argocd/update-argo-manifests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUTPUT="${SCRIPT_DIR}/app/argo-non-crds.yaml"
+CRD_KUSTOMIZATION="${SCRIPT_DIR}/crds/kustomization.yaml"
+
+# Extract ArgoCD version from argocd/crds/kustomization.yaml
+VERSION=$(grep -oP 'refs/tags/\Kv[\d.]+' "${CRD_KUSTOMIZATION}" | head -1)
+
+if [[ -z "${VERSION}" ]]; then
+    echo "ERROR: Could not determine ArgoCD version from ${CRD_KUSTOMIZATION}" >&2
+    exit 1
+fi
+
+echo "ArgoCD version: ${VERSION}"
+
+INSTALL_URL="https://raw.githubusercontent.com/argoproj/argo-cd/${VERSION}/manifests/install.yaml"
+
+echo "Downloading manifests from: ${INSTALL_URL}"
+echo "Filtering out CustomResourceDefinition resources..."
+
+curl -fsSL "${INSTALL_URL}" | \
+    yq eval 'select(.kind != "CustomResourceDefinition")' - > "${OUTPUT}"
+
+echo "Done. Saved to: ${OUTPUT}"

--- a/argocd/update-argo-manifests.sh
+++ b/argocd/update-argo-manifests.sh
@@ -6,8 +6,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 OUTPUT="${SCRIPT_DIR}/app/argo-non-crds.yaml"
 CRD_KUSTOMIZATION="${SCRIPT_DIR}/crds/kustomization.yaml"
 
-# Extract ArgoCD version from argocd/crds/kustomization.yaml
-VERSION=$(grep -oP 'refs/tags/\Kv[\d.]+' "${CRD_KUSTOMIZATION}" | head -1)
+# Extract ArgoCD version from argocd/crds/kustomization.yaml (only argoproj/argo-cd URLs)
+VERSION=$(grep -oP 'argoproj/argo-cd/refs/tags/\Kv[\d.]+' "${CRD_KUSTOMIZATION}" | head -1)
 
 if [[ -z "${VERSION}" ]]; then
     echo "ERROR: Could not determine ArgoCD version from ${CRD_KUSTOMIZATION}" >&2


### PR DESCRIPTION
- Add update-argo-manifests.sh to regenerate argo-non-crds.yaml from the official ArgoCD release
- Revert KSOPS to v4.3.3